### PR TITLE
refactor: 태그 관리 방식 수정 및 리팩터링

### DIFF
--- a/src/app/tags/[tag]/page.tsx
+++ b/src/app/tags/[tag]/page.tsx
@@ -24,11 +24,6 @@ export default async function TagDetailPage({ params }: Props) {
 
   const postsOnTag = await getPostsByTag(tag);
 
-  // valid tag이더라도 실제로 그 태그를 사용하는 글이 없는 경우.
-  if (postsOnTag.length === 0) {
-    notFound();
-  }
-
   return (
     <ListSection>
       <ListHeading>
@@ -36,7 +31,7 @@ export default async function TagDetailPage({ params }: Props) {
         <strong className="underline decoration-wavy decoration-indigo-500">
           {tag}
         </strong>
-        &quot; 태그에 속한 글 목록
+        &quot; 태그
       </ListHeading>
       <PostList posts={postsOnTag} />
     </ListSection>
@@ -55,13 +50,6 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   // valid한 태그 이름이 아닌 경우.
   if (!tagSet.has(tag)) {
-    notFound();
-  }
-
-  const postsOnTag = await getPostsByTag(tag);
-
-  // valid tag이더라도 실제로 그 태그를 사용하는 글이 없는 경우.
-  if (postsOnTag.length === 0) {
     notFound();
   }
 

--- a/src/app/tags/page.tsx
+++ b/src/app/tags/page.tsx
@@ -2,10 +2,10 @@ import { Metadata } from "next";
 import ListHeading from "@/components/list-heading";
 import ListSection from "@/components/list-section";
 import TagList from "@/components/tag-list";
-import { getUsedTags } from "@/service/posts";
+import { getTags } from "@/service/tags";
 
 export default async function TagsPage() {
-  const tags = await getUsedTags();
+  const tags = await getTags();
 
   return (
     <ListSection>

--- a/src/components/post-list/index.tsx
+++ b/src/components/post-list/index.tsx
@@ -8,6 +8,10 @@ type Props = {
 };
 
 export default function PostList({ posts }: Props) {
+  if (posts.length === 0) {
+    return <p>글이 존재하지 않습니다.</p>;
+  }
+
   return (
     <ul className="flex flex-col gap-8">
       {posts.map((post, idx) => (

--- a/src/contents/tags.json
+++ b/src/contents/tags.json
@@ -1,0 +1,1 @@
+["회고", "개발 환경 설정", "React", "Babel", "Webpack", "Vite", "Next.js"]

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -6,7 +6,7 @@ export const postMatterSchema = z.object({
   title: z.string().trim().min(1),
   description: z.string().trim(),
   createdAt: z.date(),
-  tags: tagArraySchema.nullable().optional(),
+  tags: tagArraySchema.optional(),
   series: seriesSchema.shape.name.optional(),
 });
 

--- a/src/schema/posts.ts
+++ b/src/schema/posts.ts
@@ -1,12 +1,12 @@
 import { z } from "zod";
 import { seriesSchema } from "./series";
-import { tagSchema } from "./tags";
+import { tagArraySchema } from "./tags";
 
 export const postMatterSchema = z.object({
   title: z.string().trim().min(1),
   description: z.string().trim(),
   createdAt: z.date(),
-  tags: tagSchema.array().nullable().optional(),
+  tags: tagArraySchema.nullable().optional(),
   series: seriesSchema.shape.name.optional(),
 });
 

--- a/src/schema/tags.ts
+++ b/src/schema/tags.ts
@@ -1,15 +1,9 @@
 import { z } from "zod";
 
-const VALID_TAGS = [
-  "회고",
-  "개발 환경 설정",
-  "React",
-  "Babel",
-  "Webpack",
-  "Vite",
-  "Next.js",
-] as const;
-
-export const tagSchema = z.enum(VALID_TAGS);
+export const tagSchema = z.string().trim().min(1);
 
 export type Tag = z.infer<typeof tagSchema>;
+
+export const tagArraySchema = tagSchema.array();
+
+export type TagArray = z.infer<typeof tagArraySchema>;

--- a/src/service/posts.ts
+++ b/src/service/posts.ts
@@ -169,14 +169,6 @@ export async function getPostByAbsoluteUrl(url: string) {
   return posts.find((post) => post.absoluteUrl === url);
 }
 
-// valid tag들이 아닌, valid tag들 중 실제로 post에서 사용 중인 tag들을 조회
-export async function getUsedTags() {
-  const posts = await getPosts();
-  return [...new Set(posts.flatMap((post) => post.tags ?? []))].sort(
-    (tag1, tag2) => tag1.localeCompare(tag2),
-  );
-}
-
 export async function getPostsByTag(tag: Tag) {
   return (await getPosts()).filter((post) => post.tags?.includes(tag));
 }

--- a/src/service/posts.ts
+++ b/src/service/posts.ts
@@ -27,6 +27,7 @@ import {
 } from "@/schema/posts";
 import { type Tag } from "@/schema/tags";
 import { getSeriesNameSet } from "./series";
+import { getTagSet } from "./tags";
 
 const POST_FILE_EXTENSION = [".md", ".mdx"];
 
@@ -109,11 +110,13 @@ async function extractHeadingsFromMDXString(sourceMDXString: string) {
 
 export async function getPosts() {
   const validSeriesNameSet = await getSeriesNameSet();
+  const validTagSet = await getTagSet();
   const posts: Post[] = [];
   try {
     const postAbsolutePaths = await getPostAbsolutePaths();
     for (const postAbsolutePath of postAbsolutePaths) {
       const file = await readFile(postAbsolutePath, { encoding: "utf8" });
+      // front matter에 key만 작성한 경우, gray-matter가 명시적으로 null을 할당한다.
       const { content, data } = matter(file);
       const { createdAt, description, title, tags, series } =
         postMatterSchema.parse(data);
@@ -121,6 +124,15 @@ export async function getPosts() {
         throw new Error(
           `글의 front matter에 존재하지 않는 series의 이름을 작성했습니다. 작성한 series 이름: "${series}"`,
         );
+      }
+      if (tags) {
+        for (const tag of tags) {
+          if (!validTagSet.has(tag)) {
+            throw new Error(
+              `글의 front matter에 존재하지 않는 tag를 작성했습니다. 작성한 tag: "${tag}"`,
+            );
+          }
+        }
       }
       const { code: bundledContent } = await bundleMDX({
         source: content,

--- a/src/service/tags.ts
+++ b/src/service/tags.ts
@@ -1,0 +1,31 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { cwd } from "node:process";
+import { tagArraySchema } from "@/schema/tags";
+
+const TAGS_JSON_FILE_PATH = path.resolve(cwd(), "src", "contents", "tags.json");
+
+export async function getTagSet() {
+  try {
+    const fileContents = await readFile(TAGS_JSON_FILE_PATH, {
+      encoding: "utf8",
+    });
+
+    // zod로 읽어들인 배열의 스키마 검증 후, 오름차순 정렬
+    const tagArray = tagArraySchema
+      .parse(JSON.parse(fileContents))
+      .sort((tag1, tag2) => tag1.localeCompare(tag2));
+
+    return new Set(tagArray);
+  } catch (e) {
+    throw new Error(
+      "tags.json 파일을 read, parse 하는데 문제가 발생했습니다.",
+      { cause: e },
+    );
+  }
+}
+
+export async function getTags() {
+  const tagSet = await getTagSet();
+  return [...tagSet];
+}

--- a/src/service/tags.ts
+++ b/src/service/tags.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { cwd } from "node:process";
-import { tagArraySchema } from "@/schema/tags";
+import { type Tag, tagArraySchema } from "@/schema/tags";
 
 const TAGS_JSON_FILE_PATH = path.resolve(cwd(), "src", "contents", "tags.json");
 
@@ -16,7 +16,17 @@ export async function getTagSet() {
       .parse(JSON.parse(fileContents))
       .sort((tag1, tag2) => tag1.localeCompare(tag2));
 
-    return new Set(tagArray);
+    const tagSet = new Set<Tag>();
+    for (const tag of tagArray) {
+      if (tagSet.has(tag)) {
+        throw new Error(
+          `중복된 tag가 tags.json 파일에 존재합니다. 중복 tag: "${tag}"`,
+        );
+      }
+      // js의 set은 순서가 유지된다.
+      tagSet.add(tag);
+    }
+    return tagSet;
   } catch (e) {
     throw new Error(
       "tags.json 파일을 read, parse 하는데 문제가 발생했습니다.",


### PR DESCRIPTION
- 태그 데이터를 enum 타입으로(코드로) 관리하는 대신, json 파일에서 관리하도록 수정
- json 파일에서 태그 정보를 읽어들일 때 검증 기능 추가 및 zod로 스키마 검사
  - 파일에 중복된 태그가 있다면 error를 throw
- 태그에 속한 글이 없더라도 404 페이지가 아니라 태그 상세 페이지를 표시하고 속한 글이 없음을 알리는 메시지 표시
- 글을 markdown으로 작성할 때 tags.json 파일에 존재하지 않는 태그를 front matter에 작성하면 error를 throw 하도록 검증 기능 추가 